### PR TITLE
Ensure the created and modified times are properly set

### DIFF
--- a/src/Model/Behavior/TokenizeBehavior.php
+++ b/src/Model/Behavior/TokenizeBehavior.php
@@ -100,9 +100,13 @@ class TokenizeBehavior extends Behavior
             'foreign_key' => $id,
             'foreign_data' => $data,
         ];
+        $tokenData = array_filter($tokenData);
+        if (!isset($tokenData['foreign_data'])) {
+            $tokenData['foreign_data'] = [];
+        }
 
         $table = $this->_table->$assoc;
-        $token = $table->newEntity(array_filter($tokenData));
+        $token = $table->newEntity($tokenData);
 
         if (!$table->save($token)) {
             throw new \RuntimeException();

--- a/src/Model/Table/TokensTable.php
+++ b/src/Model/Table/TokensTable.php
@@ -20,6 +20,8 @@ class TokensTable extends Table
         $this->table('tokenize_tokens');
         $this->primaryKey('id');
         $this->displayField('token');
+
+        $this->addBehavior('Timestamp');
     }
 
     public function findToken(Query $query, array $options)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,7 @@ $findRoot = function ($root) {
     throw new Exception("Cannot find the root of the application, unable to run tests");
 };
 $root = $findRoot(__FILE__);
-$path = dirname(dirname(__FILE__)) . DS;
+$path = dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR;
 unset($findRoot);
 
 chdir($root);


### PR DESCRIPTION
If the TimestampBehavior is not loaded, then these fields will not be set, and as there are no default values, all saves will break.