### PR TITLE
TableSchema instead of Schema in TokensTable.php

### DIFF
--- a/src/Model/Table/TokensTable.php
+++ b/src/Model/Table/TokensTable.php
@@ -108,7 +108,7 @@ class TokensTable extends Table
      * @param \Cake\Database\Schema\Table $schema Schema
      * @return \Cake\Database\Schema\Table
      */
-    protected function _initializeSchema(Schema $schema)
+    protected function _initializeSchema(TableSchema $schema)
     {
         $schema->columnType('foreign_data', 'json');
 


### PR DESCRIPTION
Strict (2048): Declaration of Muffin\Tokenize\Model\Table\TokensTable::_initializeSchema() should be compatible with Cake\ORM\Table::_initializeSchema(Cake\Database\Schema\TableSchema $schema) [ROOT/vendor/muffin/tokenize/src/Model/Table/TokensTable.php, line 117]