### PR TITLE
TableSchema instead of Table in TokensTable.php

### DIFF
--- a/src/Model/Table/TokensTable.php
+++ b/src/Model/Table/TokensTable.php
@@ -1,7 +1,7 @@
 <?php
 namespace Muffin\Tokenize\Model\Table;
 
-use Cake\Database\Schema\Table as Schema;
+use Cake\Database\Schema\TableSchema as Schema;
 use Cake\Event\Event;
 use Cake\ORM\Query;
 use Cake\ORM\Table;


### PR DESCRIPTION
Strict (2048): Declaration of Muffin\Tokenize\Model\Table\TokensTable::_initializeSchema() should be compatible with Cake\ORM\Table::_initializeSchema(Cake\Database\Schema\TableSchema $schema) [ROOT/vendor/muffin/tokenize/src/Model/Table/TokensTable.php, line 117]