### PR TITLE
Update Token.php

### DIFF
--- a/src/Model/Behavior/TokenizeBehavior.php
+++ b/src/Model/Behavior/TokenizeBehavior.php
@@ -19,7 +19,7 @@ class TokenizeBehavior extends Behavior
         'associationAlias' => 'Tokens',
         'implementedEvents' => [
             'Model.beforeSave' => 'beforeSave',
-        ]
+        ],
     ];
 
     /**

--- a/src/Model/Entity/Token.php
+++ b/src/Model/Entity/Token.php
@@ -34,7 +34,7 @@ class Token extends Entity
         $properties += [
             'token' => self::random(),
             'status' => false,
-            'expired' => date('Y-m-d H:i:s', strtotime($lifetime))
+            'expired' => date('Y-m-d H:i:s', strtotime($lifetime)),
         ];
         parent::__construct($properties, $options);
     }

--- a/src/Model/Entity/Token.php
+++ b/src/Model/Entity/Token.php
@@ -13,7 +13,7 @@ use Cake\Utility\Security;
  * @property string $foreign_alias
  * @property string $foreign_table
  * @property string $foreign_key
- * @property string $foreign_data
+ * @property array $foreign_data
  * @property bool $status
  */
 class Token extends Entity

--- a/src/Model/Table/TokensTable.php
+++ b/src/Model/Table/TokensTable.php
@@ -44,7 +44,7 @@ class TokensTable extends Table
         $options += [
             'token' => null,
             'expired >' => new DateTime(),
-            'status' => false
+            'status' => false,
         ];
 
         return $query->where($options);

--- a/tests/Fixture/TokensFixture.php
+++ b/tests/Fixture/TokensFixture.php
@@ -22,7 +22,7 @@ class TokensFixture extends TestFixture
         'modified' => ['type' => 'datetime'],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
-        ]
+        ],
     ];
 
     public $records = [

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -15,7 +15,7 @@ class UsersFixture extends TestFixture
         'password' => ['type' => 'string'],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
-        ]
+        ],
     ];
 
     public $records = [


### PR DESCRIPTION
I want to suggest the followings:

The `foreign_data` _datatype_ should be an **array** because of this:

```php
    /**
     * @param \Cake\Database\Schema\TableSchema $schema Schema
     * @return \Cake\Database\Schema\TableSchema
     */
    protected function _initializeSchema(TableSchema $schema)
    {
        $schema->setColumnType('foreign_data', 'json');

        return $schema;
    }
```

Code reference: https://github.com/UseMuffin/Tokenize/blob/master/src/Model/Table/TokensTable.php#L118

Further readings: 

>The code above maps the preferences column to the json custom type. This means that when retrieving data for that column, it will be unserialized from a JSON string in the database and put into an entity as an array.

Reference: https://book.cakephp.org/3/en/orm/saving-data.html#saving-complex-types

Thank you